### PR TITLE
Allow `&` in retailer name

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -72,7 +72,7 @@ components:
                 retailer:
                     description: The name of the retailer or store the receipt is from.
                     type: string
-                    pattern: "^[\\w\\s\\-]+$"
+                    pattern: "^[\\w\\s\\-&]+$"
                     example: "M&M Corner Market"
                 purchaseDate:
                     description: The date of the purchase printed on the receipt.


### PR DESCRIPTION
Follow up to #11 fixing the `M&M Corner Market` example: https://github.com/fetch-rewards/receipt-processor-challenge/blob/cf2341004742be90d75f72a72677d050f3e329b9/README.md#L121

See [this comment](https://github.com/fetch-rewards/receipt-processor-challenge/pull/11#issuecomment-1927953077) for more context. [Regex101.com link here](https://regex101.com/r/MZygEP/1) for double checking.